### PR TITLE
Add matminer

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Inspired by [awesome-python](https://awesome-python.com).
 - [DeepPurpose](https://github.com/kexinhuang12345/DeepPurpose) - A Deep Learning Library for Compound and Protein Modeling DTI, Drug Property, PPI, DDI, Protein Function Prediction.
 - [DescriptaStorus](https://github.com/bp-kelley/descriptastorus) - Descriptor computation (chemistry) and (optional) storage for machine learning.
 - [graphein](https://github.com/a-r-j/graphein) - Provides functionality for producing geometric representations of protein and RNA structures, and biological interaction networks.
-- [Matminer](https://hackingmaterials.lbl.gov/matminer/) - Library of descriptors to aid in the data-mining of materials properties, created by the Lawrence Berkeley National Laboratory.
+- [Matminer](https://github.com/hackingmaterials/matminer) - Library of descriptors to aid in the data-mining of materials properties, created by the Lawrence Berkeley National Laboratory.
 - [megnet](https://github.com/materialsvirtuallab/megnet) - Graph Networks as a Universal Machine Learning Framework for Molecules and Crystals.
 - [MAML](https://github.com/materialsvirtuallab/maml) - Aims to provide useful high-level interfaces that make ML for materials science as easy as possible.
 - [schnetpack](https://github.com/atomistic-machine-learning/schnetpack) - Deep Neural Networks for Atomistic Systems.

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Inspired by [awesome-python](https://awesome-python.com).
 - [DeepPurpose](https://github.com/kexinhuang12345/DeepPurpose) - A Deep Learning Library for Compound and Protein Modeling DTI, Drug Property, PPI, DDI, Protein Function Prediction.
 - [DescriptaStorus](https://github.com/bp-kelley/descriptastorus) - Descriptor computation (chemistry) and (optional) storage for machine learning.
 - [graphein](https://github.com/a-r-j/graphein) - Provides functionality for producing geometric representations of protein and RNA structures, and biological interaction networks.
+- [Matminer](https://hackingmaterials.lbl.gov/matminer/) - Library of descriptors to aid in the data-mining of materials properties, created by the Lawrence Berkeley National Laboratory.
 - [megnet](https://github.com/materialsvirtuallab/megnet) - Graph Networks as a Universal Machine Learning Framework for Molecules and Crystals.
 - [MAML](https://github.com/materialsvirtuallab/maml) - Aims to provide useful high-level interfaces that make ML for materials science as easy as possible.
 - [schnetpack](https://github.com/atomistic-machine-learning/schnetpack) - Deep Neural Networks for Atomistic Systems.


### PR DESCRIPTION
MatMiner is awesome because it has a ton of structural and compositional descriptors that aren't available in other packages. It's super useful for characterizing catalytic sites on metal systems, and integrates well with Pymatgen.