### PR TITLE
Added ccinput

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Inspired by [awesome-python](https://awesome-python.com).
 - [Atomic Silumation Environment (ASE)](https://wiki.fysik.dtu.dk/ase/index.html) - Is a set of tools and modules for setting up, manipulating, running, visualizing and analyzing atomistic simulations.
 - [basis_set_exchange](https://github.com/MolSSI-BSE/basis_set_exchange) - A library containing basis sets for use in quantum chemistry calculations. In addition, this library has functionality for manipulation of basis set data.
 - [CACTVS](https://www.xemistry.com/academic/) - Cactvs is a universal, scriptable cheminformatics toolkit, with a large collection of modules for property computation, chemistry data file I/O and other tasks.
+- [ccinput](https://github.com/cyllab/ccinput/) - A tool and library for creating quantum chemistry input files.
 - [cclib](https://cclib.github.io/) - A library for parsing output files various quantum chemical programs.
 - [cinfony](http://cinfony.github.io/) - A common API to several cheminformatics toolkits (Open Babel, RDKit, the CDK, Indigo, JChem, OPSIN and cheminformatics webservices).
 - [chemlab](http://chemlab.readthedocs.io/en/latest/index.html) - Is a library that can help the user with chemistry-relevant calculations.


### PR DESCRIPTION
`ccinput` is a tool and library to easily create quantum chemistry input files. It supports advanced features such as custom solvation radii and arbitrary basis sets on a per-element basis by using the `basis_set_exchange` package. As of now, it supports most features of Gaussian 16 and ORCA 5, two widely used packages, and more will be supported in the feature.

Disclaimer: I am a developer of the project.