### PR TITLE
Added Learning Resources header and SciCompforChemists Jupyter book

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ Inspired by [awesome-python](https://awesome-python.com).
 
 *Resources for learning to apply python to chemistry.*
 
-- [SciCompforChemists](https://github.com/weisscharlesj/SciCompforChemists) - A Jupyter book teaching basic Python in chemistry skills, including relevant libraries, and applies them to solve chemical problems. 
+- [SciCompforChemists](https://github.com/weisscharlesj/SciCompforChemists) - Scientific Computing for Chemists with Python is a Jupyter book teaching basic python in chemistry skills, including relevant libraries, and applies them to solving chemical problems. 
 
 ## See Also
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Inspired by [awesome-python](https://awesome-python.com).
   - [Simulations](#simulations)
   - [Molecular Visualization](#molecular-visualization)
   - [Database Wrappers](#database-wrappers)
+  - [Learning Resources](#learning-resources)
   - [See Also](#see-also)
 
 ---
@@ -163,6 +164,12 @@ Inspired by [awesome-python](https://awesome-python.com).
 - [ChemSpiPy](http://chemspipy.readthedocs.io/en/latest/) - [ChemSpider](http://www.chemspider.com/) wrapper, that allows chemical searches, chemical file downloads, depiction and retrieval of chemical properties.
 - [CIRpy](http://cirpy.readthedocs.io/en/latest/) - An interface for the Chemical Identifier Resolver (CIR) by the CADD Group at the NCI/NIH.
 - [pubchempy](http://pubchempy.readthedocs.io/en/latest/) - PubChemPy provides a way to interact with PubChem in Python.
+
+## Learning Resources
+
+*Resources for learning to apply python to chemistry.*
+
+- [SciCompforChemists](https://github.com/weisscharlesj/SciCompforChemists) - A Jupyter book teaching basic Python in chemistry skills, including relevant libraries, and applies them to solve chemical problems. 
 
 ## See Also
 


### PR DESCRIPTION
Added new heading Learning Resources for resources to help others learn to apply python to chemistry and learn relevant python libraries. I have addition resources to populate this section if accepted, but I'm sticking with one link per pull request.

The resource is a free Jupyter book titled Scientific Computing for Chemists with Python to teach python and relevant libraries (e.g., numpy, scipy, nmrglue, scikit-learn, etc...) to solving a range of chemical problems such as signal processing, boiling point prediction, solving tandem equilibrium problems, kinetic simulations, image analysis, NMR processing, etc...