### PR TITLE
Added nmrglue library to general chemistry category.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Inspired by [awesome-python](https://awesome-python.com).
 - [ionize](http://lewisamarshall.github.io/ionize/) - Calculates the properties of individual ionic species in aqueous solution, as well as aqueous solutions containing arbitrary sets of ions.
 - [LModeA-nano](https://lmodea-nano.readthedocs.io/en/latest/) - Calculates the intrinsic chemical bond strength based on local vibrational mode theory in solids and molecules.
 - [mendeleev](http://mendeleev.readthedocs.io/en/stable/) - A package that provides a python API for accessing various properties of elements from the periodic table of elements.
+- [nmrglue](https://github.com/jjhelmus/nmrglue) - A package for working with nuclear magnetic resonance (NMR) data including functions for reading common binary file formats and processing NMR data.
 - [Open Babel](http://openbabel.org/wiki/Main_Page) - A chemical toolbox designed to speak the many languages of chemical data.
 - [periodictable](https://github.com/pkienzle/periodictable) - This package provides a periodic table of the elements with support for mass, density and xray/neutron scattering information.
 - [propka](https://github.com/jensengroup/propka) - Predicts the pKa values of ionizable groups in proteins and protein-ligand complexes based in the 3D structure. 


### PR DESCRIPTION
Added nmrglue package to the General Chemistry section. nmrglue is a python package for loading, processing, and analyzing nuclear magnetic resonance (NMR) data common in chemistry. Possibly the most valuable component is the collection of functions for reading/writing common binary NMR data file formats (otherwise very challenging to read), but the package also include a number of convenient functions for processing data including phasing, referencing spectra, unit conversion (e.g., Hz to ppm), and integrating peaks.