### PR TITLE
olorenchemengine

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ Inspired by [awesome-python](https://awesome-python.com).
 - [megnet](https://github.com/materialsvirtuallab/megnet) - Graph Networks as a Universal Machine Learning Framework for Molecules and Crystals.
 - [MAML](https://github.com/materialsvirtuallab/maml) - Aims to provide useful high-level interfaces that make ML for materials science as easy as possible.
 - [MORFEUS](https://github.com/kjelljorner/morfeus) - Library for fast calculations of **mo**lecula**r** **fe**at**u**re**s** from 3D structures for machine learning with a focus on steric descriptors.
+- [olorenchemengine](https://github.com/Oloren-AI/olorenchemengine) - Molecular property prediction with unified API for diverse models and respresentations,
+  with integrated uncertainty quantification, interpretability, and hyperparameter/architecture tuning.
 - [schnetpack](https://github.com/atomistic-machine-learning/schnetpack) - Deep Neural Networks for Atomistic Systems.
 - [selfies](https://github.com/aspuru-guzik-group/selfies) - Self-Referencing Embedded Strings (SELFIES): A 100% robust molecular string representation.
 - [Summit](https://github.com/sustainable-processes/summit) - Package for optimizing chemical reactions using machine learning (contains 10 algorithms + several benchmarks).


### PR DESCRIPTION
Oloren ChemEngine (oce) is a software package developed and maintained by Oloren AI containing a unified API for the development and use of molecular property predictors enabling

Direct development of high-performing predictors
Integration of predictors into model interpretability, uncertainty quantification, and analysis frameworks
Here's an example of what we mean by this. In less than ten lines of code, we'll train, save, load, and predict with a gradient-boosted model with two different molecular vector representations.

```python
import olorenchemengine as oce

df = oce.ExampleDataFrame()

model = oce.BaseBoosting([
            oce.RandomForestModel(oce.DescriptastorusDescriptor("rdkit2dnormalized"), n_estimators=1000),
            oce.RandomForestModel(oce.OlorenCheckpoint("default"), n_estimators=1000)])
model.fit(df["Smiles"], df["pChEMBL Value"])

oce.save(model, "model.oce")

model2 = oce.load("model.oce")
```

y_pred = model2.predict(["CC(=O)OC1=CC=CC=C1C(=O)O"])
It's that simple! And it's just as simple to train a graph neural network, generate visualizations, and create error models. More information on features and capabilities is available in our documentation at [docs.oloren.ai](https://docs.oloren.ai/).