### PR TITLE
Add an entry for overreact

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Inspired by [awesome-python](https://awesome-python.com).
 - [oddt](https://github.com/oddt/oddt) - Open Drug Discovery Toolkit, a modular and comprehensive toolkit for use in cheminformatics, molecular modeling etc.
 - [OPEM](https://github.com/ECSIM/opem) - Open source PEM (Proton Exchange Membrane) fuel cell simulation tool.
 - [openmmtools](https://github.com/choderalab/openmmtools) - A batteries-included toolkit for the GPU-accelerated OpenMM molecular simulation engine.
+- [overreact](https://github.com/geem-lab/overreact) - A library and command-line tool for building and analyzing complex homogeneous microkinetic models from quantum chemistry calculations, with support for quasi-harmonic thermochemistry, quantum tunnelling corrections, molecular symmetries and more.
 - [ParmEd](https://github.com/ParmEd/ParmEd) -  Parameter/topology editor and molecular simulator with visualization capability.
 - [pGrAdd](https://github.com/VlachosGroup/PythonGroupAdditivity) - A library for estimating thermochemical properties of molecules and adsorbates using group additivity.
 - [phonopy](http://atztogo.github.io/phonopy/) - An open source package for phonon calculations at harmonic and quasi-harmonic levels.


### PR DESCRIPTION
This adds an entry for [overreact](https://geem-lab.github.io/overreact-guide/) ([GitHub](https://github.com/geem-lab/overreact), [DOI](https://doi.org/10.1002/jcc.26861)), a tool that automates the creation of complex chemical kinetic models using quantum chemistry calculations.