### PR TITLE
Add spectrochempy

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Inspired by [awesome-python](https://awesome-python.com).
 - [symfit](https://symfit.readthedocs.io/en/stable/) - a curve-fitting library ideally suited to chemistry problems, including fitting experimental kinetics data.
 - [symmetry](http://pythonhosted.org/symmetry/) - Symmetry is a library for materials symmetry analysis.
 - [stk](https://github.com/lukasturcani/stk) - A library for building, manipulating, analyzing and automatic design of molecules, including a genetic algorithm.
+- [spectrochempy](https://github.com/spectrochempy/spectrochempy) - A library for processing, analyzing and modeling spectroscopic data.
 
 ## Machine Learning
 


### PR DESCRIPTION
I always have a hard time finding this package since the documentation has a .fr domain name so it would be nice to include it here. Probably there could be a spectroscopy section but since this is the only item right now makes sense to include it in general.