### PR TITLE
add acpype to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ Inspired by [awesome-python](https://awesome-python.com).
 
 *Packages related to force fields*
 
+- [acpype](https://github.com/alanwilter/acpype) - Convert AMBER forcefields from ANTECHAMBER to GROMACS format.
 - [CHGNet](https://github.com/CederGroupHub/chgnet) - Pretrained universal neural network potential for charge-informed atomistic modeling.
 - [FitSNAP](https://github.com/FitSNAP/FitSNAP) - A Package For Training SNAP Interatomic Potentials for use in the LAMMPS molecular dynamics package.
 - [fftool](https://github.com/paduagroup/fftool) - Tool to build force field input files for molecular simulation.


### PR DESCRIPTION
Acpype is a tool based in Python to use Antechamber to generate topologies for chemical compounds and to interface with others python applications like CCPN and ARIA. Acepype can convert AMBER forcefields to CNS/XPLOR, GROMACS, CHARMM and AMBER.