### PR TITLE
Add molmass

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Inspired by [awesome-python](https://awesome-python.com).
 - [LModeA-nano](https://lmodea-nano.readthedocs.io/en/latest/) - Calculates the intrinsic chemical bond strength based on local vibrational mode theory in solids and molecules.
 - [mendeleev](http://mendeleev.readthedocs.io/en/stable/) - A package that provides a python API for accessing various properties of elements from the periodic table of elements.
 - [nmrglue](https://github.com/jjhelmus/nmrglue) - A package for working with nuclear magnetic resonance (NMR) data including functions for reading common binary file formats and processing NMR data.
+- [molmass](https://github.com/cgohlke/molmass) - Calculate mass, elemental composition, and mass distribution spectrum of a molecule given by its chemical formula, relative element weights, or sequence.
 - [Open Babel](http://openbabel.org/) - A chemical toolbox designed to speak the many languages of chemical data.
 - [periodictable](https://github.com/pkienzle/periodictable) - This package provides a periodic table of the elements with support for mass, density and xray/neutron scattering information.
 - [propka](https://github.com/jensengroup/propka) - Predicts the pKa values of ionizable groups in proteins and protein-ligand complexes based in the 3D structure.


### PR DESCRIPTION
molmass is awesome because it makes calculating molecular mass easy. Quick example of a 4-nucleotide, single-stranded RNA:

```
In [3]: molmass.Formula('ssrna(AUGC)')
Out[3]: Formula('((C10H12N5O6P)(C9H12N3O7P)(C10H12N5O7P)(C9H11N2O8P)H2O)')

In [4]: molmass.Formula('ssrna(AUGC)').spectrum(min_intensity=0.1).dataframe()
Out[4]: 
             Relative mass  Fraction  Intensity %          m/z
Mass number                                                   
1303           1303.177109  0.582934   100.000000  1303.177109
1304           1304.179800  0.281254    48.247964  1304.179800
1305           1305.182090  0.101234    17.366297  1305.182090
1306           1306.184457  0.027016     4.634415  1306.184457
1307           1307.186735  0.006120     1.049916  1307.186735
1308           1308.189025  0.001195     0.205047  1308.189025
```